### PR TITLE
fix: Docker build failure

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -55,8 +55,6 @@ RUN pip3 install --no-cache-dir --pre -r requirements/requirements-inference.txt
 
 # アプリケーションファイルをコピー
 COPY app.py ./
-COPY scripts/ ./scripts/
-COPY config/ ./config/
 
 # モデルアーティファクトを直接ダウンロードして展開
 RUN mkdir -p /app/yomikata && \

--- a/dockerfile
+++ b/dockerfile
@@ -25,8 +25,10 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 # 作業ディレクトリを設定
 WORKDIR /app
 
-# requirements.txtファイルをコピー
-COPY requirements/requirements-inference.txt .
+# パッケージのメタデータとrequirementsをコピー
+COPY pyproject.toml ./
+COPY README.md ./
+COPY requirements/ ./requirements/
 
 # 必要なディレクトリを作成
 RUN mkdir -p /app/stores/dbert
@@ -43,14 +45,18 @@ RUN pip3 install --no-cache-dir \
     pandas \
     altair==4.2.2
 
-# 他の依存関係をインストール（プレリリースパッケージを許可）
-RUN pip3 install --no-cache-dir --pre -r requirements-inference.txt
+# yomikataパッケージのソースコードをコピー
+COPY yomikata/ ./yomikata/
+COPY MANIFEST.in ./
 
-# アプリケーションのソースコードをコピー
-COPY . .
+# 依存関係とパッケージをインストール
+RUN pip3 install --no-cache-dir --pre -r requirements/requirements-inference.txt && \
+    pip3 install --no-cache-dir .
 
-# ローカルのyomikataパッケージをインストール
-RUN pip3 install --no-cache-dir -e .
+# アプリケーションファイルをコピー
+COPY app.py ./
+COPY scripts/ ./scripts/
+COPY config/ ./config/
 
 # モデルアーティファクトを直接ダウンロードして展開
 RUN mkdir -p /app/yomikata && \


### PR DESCRIPTION
## 概要
mainブランチでDockerイメージのビルドが失敗している問題を修正

## 問題
- `pip3 install -e .` が `UNKNOWN-0.0.0` パッケージをビルドしてしまう
- setuptools が editable install に対応していない
- requirements ファイルのパスが正しくない

## 修正内容
1. Dockerfile の構造を最適化
   - パッケージのメタデータを先にコピー
   - 必要なファイルを適切な順序でコピー
   - editable install から通常のインストールに変更

2. ビルドプロセスの改善
   - パッケージファイルを先にコピーして依存関係を解決
   - アプリケーションファイルは最後にコピーしてキャッシュ効率を向上

## テスト
- GitHub Actions でのDockerビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)