### PR TITLE
fix: Streamlit の非推奨機能を修正

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from yomikata.dictionary import Dictionary
 from yomikata.utils import parse_furigana
 
 
-@st.cache
+@st.cache_data
 def add_border(html: str):
     WRAPPER = """<div style="overflow-x: auto; border: 1px solid #e6e9ef; border-radius: 0.5rem; padding: 1rem; margin-bottom: 1.0rem; display: inline-block">{}</div>"""
     html = html.replace("\n", " ")
@@ -26,8 +26,8 @@ def get_random_sentence():
     return df.sample(1).iloc[0].sentence
 
 
-@st.cache
-def get_dbert_prediction_and_heteronym_list(text):
+@st.cache_resource
+def load_dbert_model():
     from yomikata.dbert import dBert
     import os
 
@@ -44,13 +44,18 @@ def get_dbert_prediction_and_heteronym_list(text):
     
     try:
         reader = dBert(model_dir)
-        return reader.furigana(text), reader.heteronyms
+        return reader
     except Exception as e:
         print(f"Error initializing dBert: {str(e)}")
         raise
 
+@st.cache_data
+def get_dbert_prediction_and_heteronym_list(text):
+    reader = load_dbert_model()
+    return reader.furigana(text), reader.heteronyms
 
-@st.cache
+
+@st.cache_data
 def get_stats():
     from yomikata.config import config
     from yomikata.utils import load_dict
@@ -117,7 +122,7 @@ def get_stats():
         st.error(f"Error loading stats: {str(e)}")
         return None, None
 
-@st.cache
+@st.cache_data
 def furigana_to_spacy(text_with_furigana):
     tokens = parse_furigana(text_with_furigana)
     ents = []
@@ -212,7 +217,7 @@ if len(spacy_dict["ents"]) > 0:
 # Randomize button
 if st.button("🎲 Randomize the input sentence"):
     st.session_state.default_sentence = get_random_sentence()
-    st.experimental_rerun()
+    st.rerun()
 
 # Stats section
 global_accuracy, stats_df = get_stats()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,198 @@
+"""Tests for Streamlit app functions"""
+import pytest
+from unittest.mock import Mock, patch
+import pandas as pd
+import streamlit as st
+from streamlit.testing.v1 import AppTest
+
+
+class TestAppFunctions:
+    """Test suite for app.py functions"""
+
+    def test_add_border(self):
+        """Test add_border function"""
+        from app import add_border
+        
+        # Test with simple HTML
+        html = "<span>test</span>"
+        result = add_border(html)
+        assert "<div style=" in result
+        assert "overflow-x: auto" in result
+        assert html in result
+        
+        # Test with newlines
+        html_with_newline = "<span>test\nwith\nnewline</span>"
+        result = add_border(html_with_newline)
+        assert "\n" not in result
+        assert "test with newline" in result
+
+    def test_furigana_to_spacy(self):
+        """Test furigana_to_spacy conversion"""
+        from app import furigana_to_spacy
+        
+        # Test with furigana text
+        text = "これは{漢字/かんじ}です"
+        result = furigana_to_spacy(text)
+        
+        assert result["text"] == "漢字"
+        assert len(result["ents"]) == 1
+        assert result["ents"][0]["label"] == "かんじ"
+        assert result["ents"][0]["start"] == 0
+        assert result["ents"][0]["end"] == 2
+        
+        # Test with multiple furigana
+        text = "{人間/にんげん}は{自由/じゆう}だ"
+        result = furigana_to_spacy(text)
+        
+        assert result["text"] == "人間, 自由"
+        assert len(result["ents"]) == 2
+        assert result["ents"][0]["label"] == "にんげん"
+        assert result["ents"][1]["label"] == "じゆう"
+
+    @patch('pandas.read_csv')
+    def test_get_random_sentence(self, mock_read_csv):
+        """Test get_random_sentence function"""
+        from app import get_random_sentence
+        
+        # Mock DataFrame
+        mock_df = pd.DataFrame({
+            'sentence': ['テスト文章1', 'テスト文章2', 'テスト文章3']
+        })
+        mock_read_csv.return_value = mock_df
+        
+        # Test that it returns a sentence from the DataFrame
+        result = get_random_sentence()
+        assert result in ['テスト文章1', 'テスト文章2', 'テスト文章3']
+
+    @patch('app.load_dbert_model')
+    def test_get_dbert_prediction_and_heteronym_list(self, mock_load_model):
+        """Test get_dbert_prediction_and_heteronym_list function"""
+        from app import get_dbert_prediction_and_heteronym_list
+        
+        # Mock dBert model
+        mock_reader = Mock()
+        mock_reader.furigana.return_value = "これは{漢字/かんじ}です"
+        mock_reader.heteronyms = ["漢字"]
+        mock_load_model.return_value = mock_reader
+        
+        # Test prediction
+        result_furigana, result_heteronyms = get_dbert_prediction_and_heteronym_list("これは漢字です")
+        
+        assert result_furigana == "これは{漢字/かんじ}です"
+        assert result_heteronyms == ["漢字"]
+        mock_reader.furigana.assert_called_once_with("これは漢字です")
+
+    @patch('yomikata.utils.load_dict')
+    @patch('pathlib.Path.exists')
+    def test_get_stats(self, mock_exists, mock_load_dict):
+        """Test get_stats function"""
+        from app import get_stats
+        
+        # Mock file existence
+        mock_exists.return_value = True
+        
+        # Mock stats data
+        mock_stats = {
+            "test": {
+                "accuracy": 0.95,
+                "heteronym_performance": {
+                    "人間": {
+                        "accuracy": 0.98,
+                        "readings": {
+                            "にんげん": {"found": {"にんげん": 50}, "n": 52},
+                            "じんかん": {"found": {"じんかん": 2}, "n": 2}
+                        }
+                    },
+                    "自由": {
+                        "accuracy": 0.92,
+                        "readings": {
+                            "じゆう": {"found": {"じゆう": 46}, "n": 50}
+                        }
+                    }
+                }
+            }
+        }
+        mock_load_dict.return_value = mock_stats
+        
+        # Test stats loading
+        global_accuracy, df = get_stats()
+        
+        assert global_accuracy == 0.95
+        assert len(df) == 1  # Only "人間" has multiple readings
+        assert "人間" in df["heteronym"].values
+
+    @patch('os.path.exists')
+    @patch('os.listdir')
+    @patch('yomikata.dbert.dBert')
+    def test_load_dbert_model(self, mock_dbert, mock_listdir, mock_exists):
+        """Test load_dbert_model function"""
+        from app import load_dbert_model
+        
+        # Mock environment
+        mock_exists.return_value = True
+        mock_listdir.return_value = ['model.pth', 'config.json']
+        
+        # Mock dBert initialization
+        mock_reader = Mock()
+        mock_dbert.return_value = mock_reader
+        
+        # Test model loading
+        result = load_dbert_model()
+        
+        assert result == mock_reader
+        mock_dbert.assert_called_once()
+
+    def test_streamlit_app_structure(self):
+        """Test basic Streamlit app structure"""
+        # This test verifies that the app can be imported without errors
+        try:
+            import app
+            assert hasattr(app, 'add_border')
+            assert hasattr(app, 'furigana_to_spacy')
+            assert hasattr(app, 'get_random_sentence')
+            assert hasattr(app, 'load_dbert_model')
+            assert hasattr(app, 'get_dbert_prediction_and_heteronym_list')
+            assert hasattr(app, 'get_stats')
+        except ImportError as e:
+            pytest.fail(f"Failed to import app: {e}")
+
+
+class TestStreamlitCaching:
+    """Test suite for Streamlit caching decorators"""
+
+    def test_cache_decorators(self):
+        """Verify that functions use correct cache decorators"""
+        import app
+        import inspect
+        
+        # Check add_border uses @st.cache_data
+        assert hasattr(app.add_border, '__wrapped__')
+        
+        # Check load_dbert_model uses @st.cache_resource
+        assert hasattr(app.load_dbert_model, '__wrapped__')
+        
+        # Check get_dbert_prediction_and_heteronym_list uses @st.cache_data
+        assert hasattr(app.get_dbert_prediction_and_heteronym_list, '__wrapped__')
+        
+        # Check get_stats uses @st.cache_data
+        assert hasattr(app.get_stats, '__wrapped__')
+        
+        # Check furigana_to_spacy uses @st.cache_data
+        assert hasattr(app.furigana_to_spacy, '__wrapped__')
+
+    def test_no_deprecated_features(self):
+        """Ensure no deprecated Streamlit features are used"""
+        import app
+        import inspect
+        
+        # Read the source code
+        source = inspect.getsource(app)
+        
+        # Check for deprecated features
+        assert "@st.cache" not in source.replace("@st.cache_data", "").replace("@st.cache_resource", "")
+        assert "st.experimental_rerun" not in source
+        
+        # Verify new features are used
+        assert "@st.cache_data" in source
+        assert "@st.cache_resource" in source
+        assert "st.rerun()" in source


### PR DESCRIPTION
## 概要
Streamlitの非推奨機能を最新のAPIに移行

## 修正内容

### 1. キャッシュデコレータの更新
- `@st.cache` → `@st.cache_data` または `@st.cache_resource` に移行
  - `add_border()`: `@st.cache_data` （HTMLデータを返すため）
  - `load_dbert_model()`: `@st.cache_resource` （モデルリソースのキャッシュ）
  - `get_dbert_prediction_and_heteronym_list()`: `@st.cache_data` （予測結果のキャッシュ）
  - `get_stats()`: `@st.cache_data` （統計データのキャッシュ）
  - `furigana_to_spacy()`: `@st.cache_data` （変換結果のキャッシュ）

### 2. リラン機能の更新
- `st.experimental_rerun()` → `st.rerun()` に変更

### 3. モデルロジックの分離
- モデルのロードとテキスト処理を分離
- `load_dbert_model()`: モデルを一度だけロードしてキャッシュ
- `get_dbert_prediction_and_heteronym_list()`: テキストごとの予測結果をキャッシュ

## 影響
- Streamlit 1.28.0以降で推奨される新しいAPIを使用
- パフォーマンスの向上（モデルの再ロードを防ぐ）
- 将来のStreamlitバージョンでの互換性を確保

## テスト
- GitHub Actions でのテストが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)